### PR TITLE
Fix stale link on FAQ page

### DIFF
--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -29,7 +29,7 @@ as well as to improve testing and documentation.
 
 ## I would like to use NWB:N. How do I get started?
 
-See the (getting started)[https://oruebel.github.io/testpage/gettingstarted] page for more information.
+See the <a href="{{ site.url }}{{ site.baseurl }}/gettingstarted">Getting Started</a> page for more information.
 
 ## What is the difference between pynwb, nwb-schema and api-python?
 


### PR DESCRIPTION
There was a leftover link to a test site. I copied the link formatting from the "Getting Started" page, but I was not able to test this fix on the actual github.io site, since I don't know how to do that.