### PR TITLE
Use jekyll_redirect_from to allow best practices page to have multiple URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,5 +19,9 @@ include:
 sass:
   sass_dir: _sass
 
+# Allow the same page to be mapped to multiple URLs
+plugins:
+  - jekyll-redirect-from
+
 google_analytics: UA-134749152-1
 

--- a/_pages/best_practices.md
+++ b/_pages/best_practices.md
@@ -4,6 +4,7 @@ layout: default
 excerpt: "NWB:N Best Practices"
 sitemap: false
 permalink: /best_practices
+redirect_from: /best_practice
 ---
 
 


### PR DESCRIPTION
The best practices pages was linked to incorrectly. To fix this, this PR addes jekyll_redirect_from to the config file which then allows us to have mutliple URLs for the page by redirecting from best_practice to best_practices. 