### PR TITLE
Redirect to nwb org

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,11 +7,12 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/"><img alt="NWB:N" src="images/nwb_n_logo.png" height="30px"></a>
+      <!--<a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/"><img alt="NWB:N" src="images/nwb_n_logo.png" height="30px"></a>-->
+      <a class="navbar-brand" href="https://www.nwb.org/"><font color="red">This page has moved to nwb.org</font></a>
     </div>
     <div class="collapse navbar-collapse" id="navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="{{ site.url }}{{ site.baseurl }}/">Home</a></li>
+        <li><a href="{{ site.url }}{{ site.baseurl }}/home">Home</a></li>
         <li class="dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown" href="#">About<span class="caret"></span></a>
                <ul class="dropdown-menu">
@@ -50,7 +51,7 @@
                  <li><a href="{{ site.url }}{{ site.baseurl }}/schemalanguage"> Specification Language</a></li>
                  <li><a href="{{ site.url }}{{ site.baseurl }}/datastandard">Data Standard Schema</a></li>
                  <li><a href="{{ site.url }}{{ site.baseurl }}/storage_hdf">Data Storage Specification: HDF5</a></li>
-                 <li><a href="https://hdmf-dev.github.io/hdmfdocs" target="_blank">HDMF (used by PyNWB)</a><li>                                  
+                 <li><a href="https://hdmf-dev.github.io/hdmfdocs" target="_blank">HDMF (used by PyNWB)</a><li>
                  <li class="divider"></li>
                  <li class="dropdown-header"><b>Guidelines</b></li>
                  <li><a href="{{ site.url }}{{ site.baseurl }}/contributing">Contributing Guidelines</a></li>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -3,7 +3,7 @@ title: "NeurodataWithoutBorders: Neurophysiology"
 layout: home
 excerpt: "NWB:N"
 sitemap: false
-permalink: /
+permalink: /home
 ---
 
 # Neurodata Without Borders: Neurophysiology (NWB:N)

--- a/_pages/redirect_home.md
+++ b/_pages/redirect_home.md
@@ -1,0 +1,11 @@
+---
+title: "NeurodataWithoutBorders: Neurophysiology"
+layout: default
+excerpt: "NWB:N"
+sitemap: false
+permalink: /
+---
+
+<meta http-equiv="refresh" content="0; URL=https://www.nwb.org/">
+
+Redirecting to [nwb.org](https://www.nwb.org/)


### PR DESCRIPTION
While working on this PR, I realized that I was not sure which behavior we want for retiring our current page.  The goal of this PR is, hence, to discuss how we want to retire https://neurodatawithoutborders.github.io/  to move to nwb.org. All information from this page has already been moved to nwb.org. To ensure users are using nwb.org from now on we need to let folks know that they should not use this page any more.

**Approach 1: Leave the page in place and redirect from home**

This is the approach implemented in this PR via the following changes:

- Change the main home page to automatically redirect to nwb.org
- Move the original home page permalink from "/" to the "/home" and update the link in the main menu bar accordingly
- Replace the NWB logo in the header menu with a red note to let people know that the site has moved

Behavior:
- a user visiting the main site at https://neurodatawithoutborders.github.io/ will be automatically redirected to nwb.org 
- users visiting a specific subpage will still be able to view the original content, while seeing a warning in the main menu that the site has moved. 

**Approach 2: Move original content to new repo and remove the current page**

We could move the content from this repo to a new Git repository to make sure we have the content still available and then change this repo to just have a blank redirect page.

Behavior:
- Users would be automatically redirect to nwb.org
- Original content would still be available in a separate repo but no longer under the original URLs
- Optionally, we could also add forward pages for all original URLs to point to the corresponding new URL on nwb.org (if we care about keeping original URLs working)

@ajtritt @rly @lydiang @bendichter thoughts?

